### PR TITLE
Add support for string and integer feature flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,3 +50,5 @@ require (
 	google.golang.org/genproto v0.0.0-20180718234121-fedd2861243f
 	google.golang.org/grpc v1.13.0
 )
+
+go 1.13

--- a/launchdarkly/data_source_feature_flag.go
+++ b/launchdarkly/data_source_feature_flag.go
@@ -34,26 +34,6 @@ func dataSourceFeatureFlag() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-			"variations": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"value": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"description": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
 			"tags": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/launchdarkly/data_source_feature_flag.go
+++ b/launchdarkly/data_source_feature_flag.go
@@ -34,6 +34,26 @@ func dataSourceFeatureFlag() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"variations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"tags": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/launchdarkly/protocol.go
+++ b/launchdarkly/protocol.go
@@ -15,8 +15,9 @@ type JsonProject struct {
 }
 
 type JsonVariations struct {
-	Value string `json:"value"`
-	Name  string `json:"name"`
+	Value       interface{} `json:"value"`
+	Name        string      `json:"name"`
+	Description string      `json:"description"`
 }
 
 type JsonCustomProperty struct {

--- a/launchdarkly/protocol.go
+++ b/launchdarkly/protocol.go
@@ -14,6 +14,11 @@ type JsonProject struct {
 	Environments []JsonEnvironment `json:"environments"`
 }
 
+type JsonVariations struct {
+	Value string `json:"value"`
+	Name  string `json:"name"`
+}
+
 type JsonCustomProperty struct {
 	Name  string   `json:"name"`
 	Value []string `json:"value"`
@@ -25,6 +30,7 @@ type JsonFeatureFlag struct {
 	Description      string                        `json:"description"`
 	Temporary        bool                          `json:"temporary"`
 	IncludeInSnippet bool                          `json:"includeInSnippet"`
+	Variations       []JsonVariations              `json:"variations"`
 	Tags             []string                      `json:"tags"`
 	CustomProperties map[string]JsonCustomProperty `json:"customProperties"`
 }

--- a/launchdarkly/resource_feature_flag.go
+++ b/launchdarkly/resource_feature_flag.go
@@ -65,7 +65,7 @@ func resourceFeatureFlag() *schema.Resource {
 						},
 						"name": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 						},
 						"description": {
 							Type:     schema.TypeString,

--- a/launchdarkly/resource_feature_flag.go
+++ b/launchdarkly/resource_feature_flag.go
@@ -6,13 +6,13 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-const DEFAULT_VARIATIONS_KIND = "boolean"
 const VARIATION_NAME_KEY = "name"
 const VARIATION_DESCRIPTION_KEY = "description"
 const VARIATION_VALUE_KEY = "value"
 const VARIATIONS_STRING_KIND = "string"
 const VARIATIONS_NUMBER_KIND = "number"
 const VARIATIONS_BOOLEAN_KIND = "boolean"
+const DEFAULT_VARIATIONS_KIND = VARIATIONS_BOOLEAN_KIND
 
 func resourceFeatureFlag() *schema.Resource {
 	return &schema.Resource{

--- a/launchdarkly/resource_feature_flag.go
+++ b/launchdarkly/resource_feature_flag.go
@@ -184,7 +184,6 @@ func resourceFeatureFlagRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("temporary", response.Temporary)
 	d.Set("include_in_snippet", response.IncludeInSnippet)
 	d.Set("tags", response.Tags)
-	d.Set("variations", response.Variations)
 	d.Set("custom_properties", transformedCustomProperties)
 
 	return nil
@@ -264,46 +263,37 @@ func transformTagsFromTerraformFormat(tags []interface{}) []string {
 }
 
 func transformVariationsFromTerraformFormat(variations []interface{}, variationsKind string) ([]JsonVariations, error) {
-	transformed, err := setVariations(variations, variationsKind)
-	if err != nil {
-		return nil, err
-	}
-
-	return transformed, nil
-}
-
-func setVariations(variations []interface{}, variationsKind string) ([]JsonVariations, error) {
-	transformed := make([]JsonVariations, len(variations))
-	for index, raw := range variations {
-		rawshit := raw.(map[string]interface{})
+	transformedVariations := make([]JsonVariations, len(variations))
+	for index, rawVariationValue := range variations {
+		variation := rawVariationValue.(map[string]interface{})
 		var value interface{}
-		name := rawshit["name"].(string)
-		description := rawshit["description"].(string)
+		name := variation["name"].(string)
+		description := variation["description"].(string)
 
 		if variationsKind == "string" {
-			value = rawshit["value"].(string)
+			value = variation["value"].(string)
 		} else if variationsKind == "number" {
-			convertedNumberValue, err := strconv.Atoi(rawshit["value"].(string))
+			convertedNumberValue, err := strconv.Atoi(variation["value"].(string))
 			if err != nil {
 				return nil, err
 			}
 			value = convertedNumberValue
 		} else if variationsKind == "boolean" {
-			convertedBooleanValue, err := strconv.ParseBool(rawshit["value"].(string))
+			convertedBooleanValue, err := strconv.ParseBool(variation["value"].(string))
 			if err != nil {
 				return nil, err
 			}
 			value = convertedBooleanValue
 		}
 
-		transformed[index] = JsonVariations{
+		transformedVariations[index] = JsonVariations{
 			Name:        name,
 			Value:       value,
 			Description: description,
 		}
 	}
 
-	return transformed, nil
+	return transformedVariations, nil
 }
 
 func transformCustomPropertiesFromTerraformFormat(properties []interface{}) (map[string]JsonCustomProperty, error) {

--- a/launchdarkly/resource_feature_flag.go
+++ b/launchdarkly/resource_feature_flag.go
@@ -6,6 +6,14 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
+const DEFAULT_VARIATIONS_KIND = "boolean"
+const VARIATION_NAME_KEY = "name"
+const VARIATION_DESCRIPTION_KEY = "description"
+const VARIATION_VALUE_KEY = "value"
+const VARIATIONS_STRING_KIND = "string"
+const VARIATIONS_NUMBER_KIND = "number"
+const VARIATIONS_BOOLEAN_KIND = "boolean"
+
 func resourceFeatureFlag() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceFeatureFlagCreate,
@@ -48,7 +56,7 @@ func resourceFeatureFlag() *schema.Resource {
 			"variations_kind": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "boolean",
+				Default:      DEFAULT_VARIATIONS_KIND,
 				ValidateFunc: validateFeatureFlagVariationsType,
 				ForceNew:     true,
 			},
@@ -60,8 +68,9 @@ func resourceFeatureFlag() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"value": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateVariationValue,
 						},
 						"name": {
 							Type:     schema.TypeString,
@@ -267,19 +276,19 @@ func transformVariationsFromTerraformFormat(variations []interface{}, variations
 	for index, rawVariationValue := range variations {
 		variation := rawVariationValue.(map[string]interface{})
 		var value interface{}
-		name := variation["name"].(string)
-		description := variation["description"].(string)
+		name := variation[VARIATION_NAME_KEY].(string)
+		description := variation[VARIATION_DESCRIPTION_KEY].(string)
 
-		if variationsKind == "string" {
-			value = variation["value"].(string)
-		} else if variationsKind == "number" {
-			convertedNumberValue, err := strconv.Atoi(variation["value"].(string))
+		if variationsKind == VARIATIONS_STRING_KIND {
+			value = variation[VARIATION_VALUE_KEY].(string)
+		} else if variationsKind == VARIATIONS_NUMBER_KIND {
+			convertedNumberValue, err := strconv.Atoi(variation[VARIATION_VALUE_KEY].(string))
 			if err != nil {
 				return nil, err
 			}
 			value = convertedNumberValue
-		} else if variationsKind == "boolean" {
-			convertedBooleanValue, err := strconv.ParseBool(variation["value"].(string))
+		} else if variationsKind == VARIATIONS_BOOLEAN_KIND {
+			convertedBooleanValue, err := strconv.ParseBool(variation[VARIATION_VALUE_KEY].(string))
 			if err != nil {
 				return nil, err
 			}

--- a/launchdarkly/validations.go
+++ b/launchdarkly/validations.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 )
 
-var supportedMultiVariationsType = [2]string{"number", "string"}
 var supportedVariationsType = [3]string{"number", "string", "boolean"}
 
 func validateKey(v interface{}, k string) ([]string, []error) {

--- a/launchdarkly/validations.go
+++ b/launchdarkly/validations.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 )
 
-var supportedVariationsType = [3]string{"number", "string", "boolean"}
+var supportedVariationsType = [3]string{VARIATIONS_NUMBER_KIND, VARIATIONS_STRING_KIND, VARIATIONS_BOOLEAN_KIND}
 
 func validateKey(v interface{}, k string) ([]string, []error) {
 	value := v.(string)
@@ -48,7 +48,7 @@ func validateFeatureFlagVariationsType(v interface{}, k string) ([]string, []err
 	value, ok := v.(string)
 
 	if !ok {
-		return nil, []error{errors.New(fmt.Sprintf("expected %s to be string", k))}
+		return nil, []error{errors.New(fmt.Sprintf("expected %s to be a string", k))}
 	}
 
 	for _, validVariationsType := range supportedVariationsType {
@@ -58,6 +58,20 @@ func validateFeatureFlagVariationsType(v interface{}, k string) ([]string, []err
 	}
 
 	return nil, []error{errors.New(fmt.Sprintf("expected %s to be one of %v, got %s", k, []string{"number", "boolean", "string"}, value))}
+}
+
+func validateVariationValue(v interface{}, k string) ([]string, []error) {
+	value, ok := v.(string)
+
+	if !ok {
+		return nil, []error{errors.New(fmt.Sprintf("expected %s to be a string", k))}
+	}
+
+	if len(value) < 1 {
+		return nil, []error{errors.New(fmt.Sprintf("%s cannot be an empty string", k))}
+	}
+
+	return nil, nil
 }
 
 func validateColor(v interface{}, k string) ([]string, []error) {

--- a/launchdarkly/validations.go
+++ b/launchdarkly/validations.go
@@ -6,6 +6,9 @@ import (
 	"regexp"
 )
 
+var supportedMultiVariationsType = [2]string{"number", "string"}
+var supportedVariationsType = [3]string{"number", "string", "boolean"}
+
 func validateKey(v interface{}, k string) ([]string, []error) {
 	value := v.(string)
 
@@ -40,6 +43,22 @@ func validateFeatureFlagKey(v interface{}, k string) ([]string, []error) {
 	}
 
 	return nil, nil
+}
+
+func validateFeatureFlagVariationsType(v interface{}, k string) ([]string, []error) {
+	value, ok := v.(string)
+
+	if !ok {
+		return nil, []error{errors.New(fmt.Sprintf("expected %s to be string", k))}
+	}
+
+	for _, validVariationsType := range supportedVariationsType {
+		if value == validVariationsType {
+			return nil, nil
+		}
+	}
+
+	return nil, []error{errors.New(fmt.Sprintf("expected %s to be one of %v, got %s", k, []string{"number", "boolean", "string"}, value))}
 }
 
 func validateColor(v interface{}, k string) ([]string, []error) {


### PR DESCRIPTION
This feature allow the launch darkly provider to create feature flag resource of type boolean, string and number. Before only the default Boolean was supported.

Here what a configuration would look like : 

```
resource "launchdarkly_feature_flag" "custom_provider_test3" {
  project_key = "${var.platform_launchdarkly_feature_flag_service_project_key}"
  key         = "custom-provider-test3"
  name        = "Custom provider test3"
  description = "testing description update"
  variations_kind = "string"
  variations = [
    {
      value = "allo1"
      name = "test1"
      description = "test1 description"
    },
    {
      value = "allo2"
      name = "test2"
    },
    {
      value = "allo3"
      description = "test 3 description"
    },
  ]
}
```
variations_kind supported string, boolean and number. Json could be add later. If not set it will default to boolean.

variations is a map where you defined your variations. If not set it will default to the boolean value and will crash if someone used another variations_kind. You need to have at least 2 variations per the launchdarkly api and it will throw an error on the plan if you don't. Other than that only the value parameter is required. 

This implementation supported an user adding more variations. It will destroy/recreated if an user changed the variations_kind value.
