### PR TITLE
Fix made provider backward compatible with configuration made with version 1.0.8

### DIFF
--- a/launchdarkly/protocol.go
+++ b/launchdarkly/protocol.go
@@ -20,6 +20,11 @@ type JsonVariations struct {
 	Description string      `json:"description"`
 }
 
+type DefaultVariations struct {
+	Value       string `json:"value"`
+	Environment string `json:"environment"`
+}
+
 type JsonCustomProperty struct {
 	Name  string   `json:"name"`
 	Value []string `json:"value"`
@@ -31,6 +36,7 @@ type JsonFeatureFlag struct {
 	Description      string                        `json:"description"`
 	Temporary        bool                          `json:"temporary"`
 	IncludeInSnippet bool                          `json:"includeInSnippet"`
+	VariationsKind   string                        `json:"kind"`
 	Variations       []JsonVariations              `json:"variations"`
 	Tags             []string                      `json:"tags"`
 	CustomProperties map[string]JsonCustomProperty `json:"customProperties"`


### PR DESCRIPTION
When using  the provider against a deployment that was made with version 1.0.8 we don't see any changes.

Also changes how to defined a default variations (which is not used yet but wasn't working in any env other than dev)